### PR TITLE
docs: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotfiles
 
-My personal dotfiles for MacOS
+My personal dotfiles for macOS
 
 <img width="682" alt="Screenshot 2024-05-08 at 17 57 18" src="https://github.com/oktaysenkan/dotfiles/assets/42527467/df10e9d8-3a57-42f4-84ec-83d3e580dcab">
 
@@ -28,27 +28,63 @@ To get started with these dotfiles, follow these steps:
    ./install
    ```
 
-This script uses Dotbot for setting up the environment, linking files, and more. It will automatically handle the installation and setup process defined in `install.conf.yaml`.
+This uses [Dotbot](https://github.com/anishathalye/dotbot) to link the config
+files and run the setup scripts defined in `install.conf.yaml`. It is safe to
+re-run — everything is idempotent.
 
-## Tools and Applications Included
+## What `./install` does
 
-### Homebrew Packages and Casks
+### Linked configs
 
-- **Packages**: `thefuck`, `watchman`, `starship`, `volta`
-- **Applications**:
-  - Browsers: `google-chrome`
-  - Development tools: `iterm2`, `visual-studio-code`, `postman`, `xcodes`
-  - Utilities: `rectangle`, `raycast`, `openinterminal`, `1password`
-  - Communication: `slack`, `whatsapp`
-  - Media: `vlc`
+| Target | Source |
+| --- | --- |
+| `~/.profile`, `~/.zprofile`, `~/.zshrc` | `profile`, `zprofile`, `zshrc` |
+| `~/.gitconfig`, `~/.gitignore_global` | `gitconfig`, `gitignore_global` |
+| `~/antigen.zsh`, `~/.antigenrc` | `antigen`, `antigenrc` |
+| `~/.config/starship.toml` | `starship.toml` |
+| `~/.config/zed/*` | `zed/*` (glob) |
+| `~/Library/Application Support/Cursor/User/settings.json` | `cursor/settings.json` |
+
+### Setup scripts (`scripts/`)
+
+| Script | Purpose |
+| --- | --- |
+| `setup_brew.sh` | Install Homebrew and everything in the `Brewfile` |
+| `setup_oh_my_zsh.sh` | Install oh-my-zsh |
+| `setup_node.sh` | Install Node.js (via Volta) |
+| `setup_macos.sh` | Apply macOS defaults (Dock, Finder, screenshots, trackpad, menu bar, security) |
+| `setup_finder_sidebar.sh` | Add folders (e.g. `~/Developer`) to the Finder sidebar via `mysides` |
+| `setup_iterm2.sh` | Point iTerm2 at the vendored prefs in `iterm2/` |
+| `setup_cursor.sh` | Install the Cursor extensions listed in `cursor/extensions.txt` |
+
+## Tools and Applications
+
+### Homebrew
+
+- **Packages**: `thefuck`, `watchman`, `starship`, `volta`, `git-recent`,
+  `cocoapods`, `fastlane`, `gh`, `ffmpeg`, `webp`, `cloudflared`, `mysides`
+- **Development**: `iterm2`, `zed`, `visual-studio-code`, `postman`,
+  `xcodes-app`, `android-studio`, `expo-orbit`, `gcloud-cli`, `zulu@17`
+- **Browsers**: `google-chrome`
+- **Utilities**: `rectangle`, `raycast`, `openinterminal`, `1password`,
+  `setapp`, `handbrake-app`, `meetingbar`
+- **Communication**: `slack`, `whatsapp`, `discord`
+- **Media**: `vlc`, `spotify`
+- **AI**: `chatgpt`
 
 ### Fonts
 
-- `font-hack-nerd-font` for enhanced terminal and coding experience.
+- `font-hack-nerd-font`, `font-geist-mono-nerd-font`, `font-martian-mono-nerd-font`
 
-### Oh-my-zsh Configuration
+### Editors
 
-- `oh-my-zsh` as the foundation
-- Useful bundles like `git`, `web-search`, `docker`, `kubernetes`
-- Syntax highlighting and autosuggestions for a better terminal experience
-- The `robbyrussell` theme for Zsh
+- **Zed** — keymap, settings, `Bearded Vivid Black` theme, and
+  React / React Native / TypeScript snippets (`zed/`)
+- **Cursor** — settings plus a tracked extension list (`cursor/`)
+
+### Shell
+
+- `oh-my-zsh` with bundles: `git`, `web-search`, `command-not-found`,
+  `thefuck`, `kubernetes`
+- `zsh-syntax-highlighting` and `zsh-autosuggestions`
+- [Starship](https://starship.rs/) prompt


### PR DESCRIPTION
Refreshes the README to match the current repo:

- Documents linked configs and the `scripts/` setup steps (macOS, Finder sidebar, iTerm2, Cursor).
- Updates the Homebrew package/cask list (fixes stale `xcodes`/`handbrake` names, adds new tools).
- Adds Zed and Cursor editor sections.

> Stacked on top of #2 (base = `feat/expand-dotfiles-setup`) so the diff is README-only. GitHub will retarget to `master` once #2 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)