### PR TITLE
feat(zed): dock git panel to the left

### DIFF
--- a/zed/settings.json
+++ b/zed/settings.json
@@ -28,6 +28,9 @@
   "project_panel": {
     "dock": "left"
   },
+  "git_panel": {
+    "dock": "left"
+  },
   "minimap": {
     "show": "never"
   },


### PR DESCRIPTION
Docks the Zed git panel to the left. Left over from #2 (didn't make the squash-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)