### PR TITLE
feat(zed): add Claude Code task and keybinding

### DIFF
--- a/zed/keymap.json
+++ b/zed/keymap.json
@@ -8,7 +8,8 @@
   },
   {
     "bindings": {
-      "f1": "command_palette::Toggle"
+      "f1": "command_palette::Toggle",
+      "cmd-alt-c": ["task::Spawn", { "task_name": "Claude Code" }],
     }
   }
 ]

--- a/zed/tasks.json
+++ b/zed/tasks.json
@@ -1,0 +1,16 @@
+// Zed tasks
+//
+// For information on how to configure tasks, see the Zed
+// documentation: https://zed.dev/docs/tasks
+[
+  {
+    "label": "Claude Code",
+    "command": "c",
+    "args": [],
+    "use_new_terminal": false,
+    "allow_concurrent_runs": false,
+    "reveal": "always",
+    "reveal_target": "dock",
+    "hide": "never"
+  },
+]


### PR DESCRIPTION
## Summary
- Add a Zed task **Claude Code** that runs `c` (the `claude --dangerously-skip-permissions` alias) in the terminal dock.
- Bind the task to `cmd-alt-c` in `keymap.json`.

## Notes
- `zed/*` is globbed into `~/.config/zed/` by dotbot, so `tasks.json` is picked up automatically on the next `./install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)